### PR TITLE
Fixing version scheme for PyPI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.2.2] - ?
+## [2.0.0] - ?
+- Version bump to sync project and PyPI versioning, as per semver.
 
 ### Fixed
 - `AUTOENV_CUR_DIR` contains leading double quote (#150)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 
 setuptools.setup(
-    version='0.2.0',
+    version='2.0.0',
     name='autoenv',
     description='Directory-based environments.',
     author='Kenneth Reitz',


### PR DESCRIPTION
There's a [PyPI package for autoenv](https://pypi.python.org/pypi/autoenv/1.0.0) marked as v1.0.0, back from 2012.

Since `pip` looks for the latest package by version number rather than date, this makes a very old version of autenv the default. It's possible to get the newer code with `pip install autoenv==0.2`, but that's unintuitive\*\*, and even moreso if you're updating from v1.0

I'm proposing to kick the version up to v2.0, so that pip will work as expected, while keeping the version in line with SemVer principals. I understand there's still ongoing development here, but the interface is probably consistent enough that it won't rapidly shoot up to v42.0 or anything crazy like that. And if it does so what?

In any case, thanks for your work on this. It's a nifty little tool.

\*\* Particularly for my Python-novice coworkers, who I'm pushing on to autoenv in order to standardize the use of virtual environments. Honestly, they'll need the latest updates from master, since I make use of AUTOENV_CUR_DIR (and the quotation fix, #150) in the .env script, but that will be published with this, sort of by definition. I'm hoping it isn't too long until that happens.

To wit: I had originally typed "==2.0" in this comment, and didn't realize until some eight months later, because using "==0.2" to get the latest code really is unintuitive. My apologies to anyone I accidentally misled with that typo!