### PR TITLE
v0.3.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.2.2] - TBD
+## [0.3.0] - 2021-9-5
 
 ### Fixed
-- Updates PyPi version to latest (#161)
-
-## [0.2.1] - 2016-10-18
-
-### Fixed
-- `AUTOENV_CUR_DIR` contains leading double quote (#150)
 - Leave `$OLDPWD` intact (#141)
+- `AUTOENV_CUR_DIR` contains leading double quote (#150)
 - Prevent any alias usage (#144)
 - Broken mountpoint detection (#151)
+- Add `AUTOENV_ASSUME_YES` (#162)
+- Execute `.env.leave` when leaving directory (#167)
+- Ensure parent directory of `AUTOENV_AUTH_FILE` exists (#201)
+- Improve platform compatibility (#174, #176, #202)
 
 ## [0.2.1] - 2016-10-18
 
@@ -85,4 +84,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.1.0]: https://github.com/inishchith/autoenv/releases/tag/v0.1.0
 [0.2.0]: https://github.com/inishchith/autoenv/releases/tag/v0.2.0
 [0.2.1]: https://github.com/inishchith/autoenv/releases/tag/v0.2.1
-[0.2.2]: https://github.com/inishchith/autoenv
+[0.3.0]: https://github.com/inishchith/autoenv/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -47,17 +47,12 @@ Follow the white rabbit:
 
 Install it easily:
 
-### Mac OS X Using Homebrew
+### MacOS using Homebrew
 
     $ brew install autoenv
     $ echo "source $(brew --prefix autoenv)/activate.sh" >> ~/.bash_profile
 
-### Using pip
-
-    $ pip install autoenv
-    $ echo "source `which activate.sh`" >> ~/.bashrc
-
-### Using git
+### Using Git
 
     $ git clone git://github.com/inishchith/autoenv.git ~/.autoenv
     $ echo 'source ~/.autoenv/activate.sh' >> ~/.bashrc
@@ -72,6 +67,8 @@ their favorite AUR helper.
 You need to source activate.sh in your bashrc afterwards:
 
     $ echo 'source /usr/share/autoenv/activate.sh' >> ~/.bashrc
+
+Note that there was previously a [pip](https://pypi.org/project/autoenv) installation option, but it is no longer recommended as the package is severely out of date
 
 ## Configuration
 


### PR DESCRIPTION
This contains preparation work for the long-awaited `0.3.0` release (the last release was published in 2016!)

If merged, it will close issues pertaining to not creating a release for the latest features to the proper distribution channels. They include:

- MacOS terminal hangs (closes #188, closes #196)
- Brew version out of date (closes #193, closes #180)
- PyPi releases out of date (closes #191, closes #191, closes #187, closes #161)
- Closes #160 as Pip is no longer being recommended as an installation method 

See `CHANGELOG.md` for more specific info about the latest changes since `0.2.1`

Considerations
- Since the Pip package already has a `1.0.0` version, creating a `0.3.0` will do nothing during versionless pip installations of autoenv. Should autoenv be packaged for a different cross-platform package manager (since AUR and Homebrew are mostly specific to Arch and MacOS, respectively)? Doing this will enable easier installations

After-release checklist
- [ ] Create Homebrew PR [autoenv Formula](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/autoenv.rb) with new `v0.3.0` tag
