### PR TITLE
feat: Add `AUTOENV_NOTAUTH_FILE` to always deny permission to `source` file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ $ printf '%s\n' "source ~/.autoenv/activate.sh" >> ~/.bash_profile
 _Before_ `source`ing `activate.sh`, you can set the following variables:
 
 - `AUTOENV_AUTH_FILE`: Authorized env files; defaults to `~/.autoenv_authorized` if it exists, otherwise, `~/.local/state/autoenv/authorized_list`
+- `AUTOENV_NOTAUTH_FILE`: Env files not authorized to be sourced; defaults to a file in the same directory as `~/.autoenv_authorized` (`master` branch only)
 - `AUTOENV_ENV_FILENAME`: Name of the `.env` file; defaults to `.env`
 - `AUTOENV_LOWER_FIRST`: Set this variable to a non-empty string to flip the order of `.env` files executed
 - `AUTOENV_ENV_LEAVE_FILENAME`: Name of the `.env.leave` file; defaults to `.env.leave`

--- a/tests/test_prompt.bats
+++ b/tests/test_prompt.bats
@@ -46,3 +46,24 @@ setup() {
 	[[ "$output" == *'New or modified env file detected'* ]]
 	[[ "$output" == *'echo 123'* ]]
 }
+
+@test "Entering 'd' does not prompt again" {
+	mkdir -p './dir'
+	printf '%s\n' 'echo 123' > './dir/.env'
+
+	run bash -c "
+		source '$BATS_TEST_DIRNAME/../activate.sh'
+		cd './dir' <<< 'd'
+	"
+	[[ "$output" == *'New or modified env file detected'* ]]
+	[[ "$output" == *'echo 123'* ]]
+
+	run bash -c "
+		source '$BATS_TEST_DIRNAME/../activate.sh'
+		cd './dir' <<< 'y'
+	"
+	[[ "$output" != *'New or modified env file detected'* ]]
+	[[ "$output" != *'echo 123'* ]]
+	[[ "$output" != *'123'* ]]
+}
+


### PR DESCRIPTION
Unexpectedly, not allowing to source an `.env` file (by inputing `N`) does not "save". So, every time when `cd`ing into a directory, one must always specify to _not_ `source` the end file.

This PR fixes that by adding a third option `d`/`D` to save that choice into a file called `AUTOENV_NOTAUTH_FILE`.

Adhering to the principle of lease surprise, this file is located in `~` if `AUTOENV_AUTH_FILE` exists there too. Otherwise, it is located in `$XDG_STATE_HOME/autoenv`.

Closes #224