### PR TITLE
autoenv_leave: Only match prefix on path boundaries

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -295,18 +295,25 @@ autoenv_leave() {
 	_files=$(
 		command -v chdir >/dev/null 2>&1 && chdir "${from_dir}" || builtin cd "${from_dir}"
 		_hadone=''
-		while [ "$PWD" != "" ] && [ "$PWD" != "/" ] && [[ $to_dir/ != $PWD/* ]]; do
-			_file="$PWD/${AUTOENV_ENV_LEAVE_FILENAME}"
-			if [ -f "${_file}" ]; then
-				if [ -z "${_hadone}" ]; then
-					printf %s "${_file}"
-					_hadone='1'
-				else
-					printf %s "
+		while [ "$PWD" != "" ] && [ "$PWD" != "/" ]; do
+			case $to_dir/ in
+				$PWD/*)
+				break
+				;;
+			*)
+				_file="$PWD/${AUTOENV_ENV_LEAVE_FILENAME}"
+				if [ -f "${_file}" ]; then
+					if [ -z "${_hadone}" ]; then
+						printf %s "${_file}"
+						_hadone='1'
+					else
+						printf %s "
 ${_file}"
+					fi
 				fi
-			fi
-			command -v chdir >/dev/null 2>&1 && chdir "$(pwd)/.." || builtin cd "$PWD/.."
+				command -v chdir >/dev/null 2>&1 && chdir "$(pwd)/.." || builtin cd "$PWD/.."
+				;;
+			esac
 		done
 	)
 

--- a/activate.sh
+++ b/activate.sh
@@ -295,7 +295,7 @@ autoenv_leave() {
 	_files=$(
 		command -v chdir >/dev/null 2>&1 && chdir "${from_dir}" || builtin cd "${from_dir}"
 		_hadone=''
-		while [ "$PWD" != "" ] && [[ $to_dir != $PWD* ]]; do
+		while [ "$PWD" != "" ] && [ "$PWD" != "/" ] && [[ $to_dir/ != $PWD/* ]]; do
 			_file="$PWD/${AUTOENV_ENV_LEAVE_FILENAME}"
 			if [ -f "${_file}" ]; then
 				if [ -z "${_hadone}" ]; then

--- a/tests/test_cd_env_leave.sh
+++ b/tests/test_cd_env_leave.sh
@@ -1,0 +1,12 @@
+# shellcheck shell=sh
+
+. "${FUNCTIONS}"
+. "${ACTIVATE_SH}"
+
+# Prepare files/directories
+mkdir -pv 'a/b' 'a/bz'
+echo 'echo zulu' > 'a/b/.env.leave'
+
+AUTOENV_ENABLE_LEAVE=1
+cd 'a/b'
+patterntest 'echo "Y" | cd ../../a/bz' 'zulu$'


### PR DESCRIPTION
Suppose we `cd` from `a/b` to `a/bz`.

Expected behavior: Invoke `a/b/.env.leave.

Actual behavior prior to this commit: No env-leave is invoked.

The issue is that we are naively checking for string prefixes in `autoenv_leave` in order to determine whether one directory is an ancestor of another. This commit makes the checking slightly less naive by adding a trailing slash. This way, `a/bz/` is not a prefix of `/a/b/`.