### PR TITLE
Simplify `ALIAS_FUNC_DEF` checks

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -337,30 +337,30 @@ ${_file}"
 	fi
 }
 
-# Override the cd alias
-if \command -v setopt >/dev/null 2>&1; then
-	if \setopt 2> /dev/null | \command grep -q aliasfuncdef; then
-		has_alias_func_def_enabled=true
-	else
-		\setopt ALIAS_FUNC_DEF 2>/dev/null
-	fi
-fi
-
 # @description Run to automatically replace the cd builtin with our improved one
 enable_autoenv() {
 	if [ -z "${AUTOENV_PRESERVE_CD}" ]; then
+		# Override the cd alias
+		if [ -n "$ZSH_VERSION" ] && [[ ! -o aliasfuncdef ]]; then
+			# if \setopt 2> /dev/null | \command grep -q aliasfuncdef; then
+				has_alias_func_def_enabled=yes
+			# else
+				\setopt ALIAS_FUNC_DEF 2>/dev/null
+			# fi
+		fi
+
 		cd() {
 			autoenv_cd "${@}"
 		}
+
+		if [ "$has_alias_func_def_enabled" = 'yes' ]; then
+			\unsetopt ALIAS_FUNC_DEF 2> /dev/null
+		fi
 	fi
 
 	# shellcheck disable=SC2164
 	cd "${PWD}"
 }
-
-if ! $has_alias_func_def_enabled; then
-	\unsetopt ALIAS_FUNC_DEF 2> /dev/null
-fi
 
 __autoenv_has_builtin=no
 if __autoenv_output=$(\type builtin); then

--- a/activate.sh
+++ b/activate.sh
@@ -337,30 +337,28 @@ ${_file}"
 	fi
 }
 
+# Set Zsh option to prevent errors when "cd" is already an alias.
+if [ -n "${ZSH_VERSION:-}" ] && [[ ! -o aliasfuncdef ]]; then
+	__autoenv_unset_aliasfuncdef=yes
+	\setopt ALIAS_FUNC_DEF 2>/dev/null
+fi
+
 # @description Run to automatically replace the cd builtin with our improved one
 enable_autoenv() {
 	if [ -z "${AUTOENV_PRESERVE_CD}" ]; then
-		# Override the cd alias
-		if [ -n "$ZSH_VERSION" ] && [[ ! -o aliasfuncdef ]]; then
-			# if \setopt 2> /dev/null | \command grep -q aliasfuncdef; then
-				has_alias_func_def_enabled=yes
-			# else
-				\setopt ALIAS_FUNC_DEF 2>/dev/null
-			# fi
-		fi
-
 		cd() {
 			autoenv_cd "${@}"
 		}
-
-		if [ "$has_alias_func_def_enabled" = 'yes' ]; then
-			\unsetopt ALIAS_FUNC_DEF 2> /dev/null
-		fi
 	fi
 
 	# shellcheck disable=SC2164
 	cd "${PWD}"
 }
+
+if [ "${__autoenv_unset_aliasfuncdef:-}" = 'yes' ]; then
+	\unsetopt ALIAS_FUNC_DEF 2>/dev/null
+	\unset -v __autoenv_unset_aliasfuncdef
+fi
 
 __autoenv_has_builtin=no
 if __autoenv_output=$(\type builtin); then


### PR DESCRIPTION
Improves check by:

- Using simple string and option condition tests instead of pipes
- Ensure that `has_alias_func_def_enabled` does not have global scope
- Correct misleading comment

Setting this option does not allow autoenv to "Override the cd alias" as the comment suggests. Aliases still have priority, say, when executing `cd`.

What the option does so, is allow Zsh to parse the function definition without erroring. Then, the autoenv cd can be invoked like `\cd`.

Note that with this behavior, Zsh will _silently fail_ setting the autoenv-defined `cd` function. Say, if the user sets `alias cd=something` before sourcing `autoenv.sh`, the autoenv-defined cd function will be called `something` instead.

Another approach is to define functions with the `function` keyword (Bash and Zsh), or use quotes around (`"cd"() { :; }`) (Zsh-only). To avoid errors with shells like Dash, `eval` can be used but I've opted to keep the existing code for simplicity and consistency with older versions of autoenv.