### PR TITLE
Replaces uses of `eval`

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -231,12 +231,9 @@ _autoenv_check_authz_and_run() {
 # @description Mark an env file as able to be sourced
 # @internal
 autoenv_deauthorize_env() {
-	local _envfile="${1}" _noclobber
+	local _envfile="${1}"
 	\command cp -- "${AUTOENV_AUTH_FILE}" "${AUTOENV_AUTH_FILE}.tmp"
-	_noclobber="$(\set +o | \command grep noclobber)"
-	\set +C
-	\command grep -Gv "${_envfile}:" -- "${AUTOENV_AUTH_FILE}.tmp" > "${AUTOENV_AUTH_FILE}"
-	\eval "${_noclobber}"
+	\command grep -Gv "${_envfile}:" -- "${AUTOENV_AUTH_FILE}.tmp" >| "${AUTOENV_AUTH_FILE}"
 	\command rm -- "${AUTOENV_AUTH_FILE}.tmp" 2>/dev/null || :
 }
 
@@ -259,14 +256,18 @@ autoenv_authorize_env() {
 # @description Actually source a file
 # @internal
 autoenv_source() {
-	local _allexport
-	_allexport="$(\set +o | \command grep allexport)"
-	\set -a
+	case $-) in
+	*a*) ;;
+	*) \set -a; __autoenv_set_allexport=yes ;;
+	esac
+
 	AUTOENV_CUR_FILE="${1}"
 	AUTOENV_CUR_DIR="$(\command dirname "${1}")"
 	. "${1}"
-	[ "${ZSH_VERSION#*5.1}" != "${ZSH_VERSION}" ] && \set +a
-	\eval "${_allexport}"
+
+	if [ "${__autoenv_set_allexport:-}" = 'yes' ]; then
+		\set +a
+	fi
 	\unset AUTOENV_CUR_FILE AUTOENV_CUR_DIR
 }
 

--- a/activate.sh
+++ b/activate.sh
@@ -258,7 +258,7 @@ autoenv_authorize_env() {
 autoenv_source() {
 	case $-) in
 	*a*) ;;
-	*) \set -a; __autoenv_set_allexport=yes ;;
+	*) \set -a; local __autoenv_set_allexport=yes ;;
 	esac
 
 	AUTOENV_CUR_FILE="${1}"

--- a/activate.sh
+++ b/activate.sh
@@ -256,7 +256,7 @@ autoenv_authorize_env() {
 # @description Actually source a file
 # @internal
 autoenv_source() {
-	case $-) in
+	case $- in
 	*a*) ;;
 	*) \set -a; local __autoenv_set_allexport=yes ;;
 	esac

--- a/tests/test_variables.bats
+++ b/tests/test_variables.bats
@@ -1,0 +1,41 @@
+# shellcheck shell=bash
+
+load './util/init.sh'
+
+@test "Variable AUTOENV_CUR_FILE is exported and correct" {
+	source "$BATS_TEST_DIRNAME/../activate.sh"
+	cat > .env <<"EOF"
+printf '%s\n' "file: $AUTOENV_CUR_FILE"
+if export -p | grep -q AUTOENV_CUR_FILE; then
+	printf '%s\n' "AUTOENV_CUR_FILE exported"
+fi
+if [[ -o allexport ]]; then
+	printf '%s\n' "option: allexport set"
+fi
+EOF
+	local expected_cur_file="$PWD/.env"
+
+	run cd .
+	[ "$output" = "file: $expected_cur_file
+AUTOENV_CUR_FILE exported
+option: allexport set" ]
+}
+
+@test "Variable AUTOENV_CUR_DIR is exported and correct" {
+	source "$BATS_TEST_DIRNAME/../activate.sh"
+	cat > .env <<"EOF"
+printf '%s\n' "file: $AUTOENV_CUR_DIR"
+if export -p | grep -q AUTOENV_CUR_DIR; then
+	printf '%s\n' "AUTOENV_CUR_DIR exported"
+fi
+if [[ -o allexport ]]; then
+	printf '%s\n' "option: allexport set"
+fi
+EOF
+	local expected_cur_file="$PWD"
+
+	run cd .
+	[ "$output" = "file: $expected_cur_file
+AUTOENV_CUR_DIR exported
+option: allexport set" ]
+}


### PR DESCRIPTION
The first eval was used to execute code from an earlier `set +o`, so `noclobber` can be enabled. Better is to use `|>`, which is specified by POSIX:

> Output redirection using the '>' format shall fail if the noclobber shell option is set (see the description of [set](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set) -C) and the file named by the expansion of word exists and is a regular file. Otherwise, redirection using the '>' or ">|" formats shall cause the file whose name results from the expansion of word to be created and opened for output on the designated file descriptor, or standard output if none is specified. If the file does not exist, it shall be created; otherwise, it shall be truncated to be an empty file after being opened.

The second eval was similarly used for the `allexport` shell option. That was replaced through the evaluation of `$-` and a condition check to restore the previous option value if it was just changed.

Not sure what the `[ "${ZSH_VERSION#*5.1}" != "${ZSH_VERSION}" ] && set +a` line was about... I blamed it to PR #113 (associated with merge commit c95ac188dcb730e8fc7d7ecfd16b089d7327c861). The condition originally tested if the `$ZSH_VERSION` was some patch release of `5.1`.  But then in that PR, a bug was added where any release that contains the string `5.1` passes the condition.  Remove this condition because it should be covered by the existing POSIX compatible code anyways.